### PR TITLE
Fix description running time from O(N^2) to O(n)

### DIFF
--- a/Sources/LinkedList.swift
+++ b/Sources/LinkedList.swift
@@ -66,13 +66,7 @@ extension LinkedList: SequenceType {
 
 extension LinkedList: CustomStringConvertible {
     public var description: String {
-        var str = "["
-        for (i, x) in enumerate() {
-            str += "\(x)"
-            if i != self.endIndex { str += ", " }
-        }
-        str += "]"
-        return str
+        return "[\(map({"\($0)"}).joinWithSeparator(", "))]"
     }
 }
 


### PR DESCRIPTION
Hi,

Great implementation! Thank you ! Just my 2 cents here:

Every time you get **endIndex** you traverse whole list to the last element O(n). Since you where using it in outer loop with n elements as well -  description operation was O(n^2).
:)

Happy coding!
